### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,19 @@
-# Copyright 2019 Xanadu Quantum Technologies Inc.
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     http://aws.amazon.com/apache2.0/
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
 
 #!/usr/bin/env python3
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 with open("pennylane_braket/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
@@ -34,8 +33,7 @@ setup(
     version=version,
     license="Apache License 2.0",
     python_requires=">= 3.7.2",
-    packages=find_packages(where="pennylane_braket", exclude=("tests",)),
-    package_dir={"": "pennylane_braket"},
+    packages=["pennylane_braket"],
     install_requires=requirements,
     entry_points={
         "pennylane.plugins": [


### PR DESCRIPTION
`packages` now points directly to the `pennylane_braket` directory

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
