### PR TITLE
Only apply identity to unused qubits

### DIFF
--- a/src/pennylane_braket/braket_device.py
+++ b/src/pennylane_braket/braket_device.py
@@ -100,13 +100,11 @@ class BraketDevice(QubitDevice):
 
         self._circuit = None
         self._task = None
-        self._result = None
 
     def reset(self):
         super().reset()
         self._circuit = None
         self._task = None
-        self._result = None
 
     @property
     def operations(self) -> Set[str]:
@@ -125,12 +123,6 @@ class BraketDevice(QubitDevice):
         """ QuantumTask: The task corresponding to the last run circuit.
         """
         return self._task
-
-    @property
-    def result(self) -> GateModelQuantumTaskResult:
-        """ GateModelQuantumTaskResult: The result of the last run task.
-        """
-        return self._result
 
     def apply(self, operations, rotations=None, **kwargs):
         """Instantiate Braket Circuit object."""
@@ -161,11 +153,13 @@ class BraketDevice(QubitDevice):
             shots=self.shots,
             poll_timeout_seconds=self._poll_timeout_seconds
         )
-        self._result = self._task.result()
-        return self._result.measurements
+        return self._task.result().measurements
 
     def probability(self, wires=None):
-        probs = {int(s, 2): p for s, p in self._result.measurement_probabilities.items()}
+        probs = {
+            int(s, 2): p
+            for s, p in self._task.result().measurement_probabilities.items()
+        }
         probs_list = np.array([probs[i] if i in probs else 0 for i in range(2 ** self.num_wires)])
         return self.marginal_prob(probs_list, wires=wires)
 

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -36,6 +36,8 @@ RESULT = GateModelQuantumTaskResult.from_string(
         }
     )
 )
+TASK = Mock()
+TASK.result.return_value = RESULT
 BELL_STATE = Circuit().h(0).cnot(0, 1)
 
 
@@ -48,11 +50,11 @@ def test_reset():
         shots=10000,
     )
     dev._circuit = BELL_STATE
-    dev._result = RESULT
+    dev._task = TASK
 
     dev.reset()
     assert dev.circuit is None
-    assert dev.result is None
+    assert dev.task is None
 
 
 def test_apply():
@@ -107,9 +109,7 @@ def test_apply_unsupported():
 
 @patch.object(AwsQuantumTask, "create")
 def test_generate_samples_ionq(mock_create):
-    task = Mock()
-    task.result.return_value = RESULT
-    mock_create.return_value = task
+    mock_create.return_value = TASK
     dev = AWSIonQDevice(
         wires=2,
         s3_destination_folder=("foo", "bar"),
@@ -118,7 +118,7 @@ def test_generate_samples_ionq(mock_create):
     dev.apply([qml.Hadamard(wires=0), qml.CNOT(wires=[0, 1])])
 
     assert (dev.generate_samples() == RESULT.measurements).all()
-    assert dev.task == task
+    assert dev.task == TASK
     mock_create.assert_called_with(
         mock.ANY,
         AwsQpuArns.IONQ,
@@ -131,9 +131,7 @@ def test_generate_samples_ionq(mock_create):
 
 @patch.object(AwsQuantumTask, "create")
 def test_generate_samples_rigetti(mock_create):
-    task = Mock()
-    task.result.return_value = RESULT
-    mock_create.return_value = task
+    mock_create.return_value = TASK
 
     dev = AWSRigettiDevice(
         wires=2,
@@ -143,7 +141,7 @@ def test_generate_samples_rigetti(mock_create):
     dev.apply([qml.Hadamard(wires=0), qml.CNOT(wires=[0, 1])])
 
     assert (dev.generate_samples() == RESULT.measurements).all()
-    assert dev.task == task
+    assert dev.task == TASK
     mock_create.assert_called_with(
         mock.ANY,
         AwsQpuArns.RIGETTI,
@@ -156,9 +154,7 @@ def test_generate_samples_rigetti(mock_create):
 
 @patch.object(AwsQuantumTask, "create")
 def test_generate_samples_qs1(mock_create):
-    task = Mock()
-    task.result.return_value = RESULT
-    mock_create.return_value = task
+    mock_create.return_value = TASK
 
     dev = AWSSimulatorDevice(
         wires=2,
@@ -169,7 +165,7 @@ def test_generate_samples_qs1(mock_create):
     dev.apply([qml.Hadamard(wires=0), qml.CNOT(wires=[0, 1])])
 
     assert (dev.generate_samples() == RESULT.measurements).all()
-    assert dev.task == task
+    assert dev.task == TASK
     mock_create.assert_called_with(
         mock.ANY,
         AwsQuantumSimulatorArns.QS1,
@@ -182,9 +178,7 @@ def test_generate_samples_qs1(mock_create):
 
 @patch.object(AwsQuantumTask, "create")
 def test_generate_samples_qs2(mock_create):
-    task = Mock()
-    task.result.return_value = RESULT
-    mock_create.return_value = task
+    mock_create.return_value = TASK
 
     dev = AWSSimulatorDevice(
         wires=2,
@@ -195,7 +189,7 @@ def test_generate_samples_qs2(mock_create):
     dev.apply([qml.Hadamard(wires=0), qml.CNOT(wires=[0, 1])])
 
     assert (dev.generate_samples() == RESULT.measurements).all()
-    assert dev.task == task
+    assert dev.task == TASK
     mock_create.assert_called_with(
         mock.ANY,
         AwsQuantumSimulatorArns.QS2,
@@ -208,9 +202,7 @@ def test_generate_samples_qs2(mock_create):
 
 @patch.object(AwsQuantumTask, "create")
 def test_generate_samples_qs3(mock_create):
-    task = Mock()
-    task.result.return_value = RESULT
-    mock_create.return_value = task
+    mock_create.return_value = TASK
 
     dev = AWSSimulatorDevice(
         wires=2,
@@ -220,7 +212,7 @@ def test_generate_samples_qs3(mock_create):
     dev.apply([qml.Hadamard(wires=0), qml.CNOT(wires=[0, 1])])
 
     assert (dev.generate_samples() == RESULT.measurements).all()
-    assert dev.task == task
+    assert dev.task == TASK
     mock_create.assert_called_with(
         mock.ANY,
         AwsQuantumSimulatorArns.QS3,
@@ -239,6 +231,6 @@ def test_probability():
         s3_destination_folder=("foo", "bar"),
         shots=10000,
     )
-    dev._result = RESULT
+    dev._task = TASK
     probs = np.array([0.25, 0, 0, 0.75])
     assert (dev.probability() == dev.marginal_prob(probs)).all()


### PR DESCRIPTION
Removes I gates applied to every qubit at the start of the circuit,
only applies them to unused qubits at the end of the circuit.

This is a stopgap measure until custom qubit mapping is implemented
in the Braket SDK.

Also gives customers access to the task created by the device if needed.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
