### PR TITLE
removed reference to QS2 and replace it with QS1

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -39,7 +39,7 @@ The Braket devices accept additional arguments beyond the PennyLane default devi
 
 Additionally, ``AWSSimulatorDevice`` accepts
 
-* **backend** (*str*) -- The simulator backend to target; can be one of "QS1", "QS2" or "QS3". Defaults to "QS3".
+* **backend** (*str*) -- The simulator backend to target; "QS1". Defaults to "QS1".
 
 Supported operations
 ====================

--- a/example.py
+++ b/example.py
@@ -5,7 +5,7 @@ s3 = ("my-bucket", "my-prefix")
 dev_qs2 = qml.device(
 	"braket.simulator",
 	s3_destination_folder=s3,
-	backend="QS2",
+	backend="QS1",
 	wires=2
 )
 dev_qpu = qml.device(


### PR DESCRIPTION
*Issue #, if available:*

Regarding this email
> EOD today, QS2 and QS3 will be deprecated and you will not be able to access these backends anymore. We are planning to bring back a variation of a Tensor Network simulator (QS2) in a different form.
QS1, our default state vector simulator, will be relaunched next week and different performance and functionality upgrades will be introduced over the upcoming weeks.

*Description of changes:*
I removed references to QS2 and replace it with QS1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
