### PR TITLE
Fix: Redirect default polling times to defaults in AwsQuantumTask.

### DIFF
--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -39,7 +39,7 @@ import functools
 from typing import FrozenSet, List, Optional, Sequence, Union
 
 import numpy as np
-from braket.aws import AwsDevice, AwsDeviceType, AwsSession
+from braket.aws import AwsDevice, AwsDeviceType, AwsQuantumTask, AwsSession
 from braket.circuits import Circuit, Instruction
 from braket.device_schema import DeviceActionType
 from braket.devices import Device, LocalSimulator
@@ -239,7 +239,8 @@ class BraketAwsQubitDevice(BraketQubitDevice):
         s3_destination_folder: AwsSession.S3DestinationFolder,
         *,
         shots: Optional[int] = None,
-        poll_timeout_seconds: int = AwsDevice.DEFAULT_RESULTS_POLL_TIMEOUT,
+        poll_timeout_seconds: float = AwsQuantumTask.DEFAULT_RESULTS_POLL_TIMEOUT,
+        poll_interval_seconds: float = AwsQuantumTask.DEFAULT_RESULTS_POLL_INTERVAL,
         aws_session: Optional[AwsSession] = None,
         parallel: bool = False,
         **run_kwargs,
@@ -263,6 +264,7 @@ class BraketAwsQubitDevice(BraketQubitDevice):
         super().__init__(wires, device, shots=num_shots, **run_kwargs)
         self._s3_folder = s3_destination_folder
         self._poll_timeout_seconds = poll_timeout_seconds
+        self._poll_interval_seconds = poll_interval_seconds
         self._parallel = parallel
 
     @property
@@ -303,6 +305,7 @@ class BraketAwsQubitDevice(BraketQubitDevice):
             s3_destination_folder=self._s3_folder,
             shots=0 if self.analytic else self.shots,
             poll_timeout_seconds=self._poll_timeout_seconds,
+            poll_interval_seconds=self._poll_interval_seconds,
             **self._run_kwargs,
         )
 

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -240,8 +240,8 @@ def test_execute(mock_create, _execute):
         CIRCUIT,
         ("foo", "bar"),
         SHOTS,
-        poll_timeout_seconds=AwsDevice.DEFAULT_RESULTS_POLL_TIMEOUT,
-        poll_interval_seconds=AwsDevice.DEFAULT_RESULTS_POLL_INTERVAL,
+        poll_timeout_seconds=AwsQuantumTask.DEFAULT_RESULTS_POLL_TIMEOUT,
+        poll_interval_seconds=AwsQuantumTask.DEFAULT_RESULTS_POLL_INTERVAL,
         foo="bar",
     )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Following the unification of poll defaults in the Braket SDK (https://github.com/aws/amazon-braket-sdk-python/pull/173/commits/3002b8ed69cd6735b3eac9dc67d641ab2bba40f5), redirect the default polling times in this plugin to point to the new poll defaults.
*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.