### PR TITLE
documentation: Mention tape mode and link to Braket quota details

### DIFF
--- a/doc/devices/braket_remote.rst
+++ b/doc/devices/braket_remote.rst
@@ -45,8 +45,9 @@ Enabling the parallel execution of multiple circuits
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Where supported by the backend of the Amazon Braket service, the remote device can be used to execute multiple
-quantum circuits in parallel. To unlock this feature, instantiate the device using the ``parallel=True`` argument:
+quantum circuits in parallel. To unlock this feature, make sure `tape mode <https://pennylane.readthedocs.io/en/stable/code/qml_tape.html>`_ is enabled in PennyLane, and then instantiate the device using the ``parallel=True`` argument:
 
+>>> qml.enable_tape()
 >>> remote_device = qml.device('braket.aws.qubit', [... ,] parallel=True)
 
 The details of the parallelization scheme depend on the PennyLane version you use, as well as your AWS account specifications.
@@ -59,7 +60,7 @@ The maximum number of circuits that can be executed in parallel is specified by 
 
 >>> remote_device = qml.device('braket.aws.qubit', [... ,] parallel=True, max_parallel=20)
 
-Make sure that this number is not larger than the maximum number of workers set for your account.
+Make sure that this number is not larger than the maximum number of concurrent tasks allowed for your account on the backend you choose. See the `Braket developer guide <https://docs.aws.amazon.com/braket/latest/developerguide/braket-quotas.html>`_ for more details.
 
 The Braket remote device has the capability to retry failed circuit executions, up to 3 times per circuit by default.
 You can set a timeout by using the ``poll_timeout_seconds`` argument;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In readthedocs, mention that `qml.enable_tape()` is required to enable parallel execution for gradient calculations.

Also add a link for Braket service quotas.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.