### PR TITLE
Remove legacy return types system

### DIFF
--- a/src/braket/pennylane_plugin/_version.py
+++ b/src/braket/pennylane_plugin/_version.py
@@ -15,4 +15,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "1.20.3.post1"
+__version__ = "1.20.4.dev0"

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -1207,9 +1207,8 @@ def test_batch_execute_parametrize_differentiable(mock_run_batch):
     )
 
 
-@pytest.mark.parametrize("old_return_type", [True, False])
 @patch.object(AwsDevice, "run")
-def test_execute_all_samples(mock_run, old_return_type):
+def test_execute_all_samples(mock_run):
     result = GateModelQuantumTaskResult.from_string(
         json.dumps(
             {
@@ -1265,19 +1264,15 @@ def test_execute_all_samples(mock_run, old_return_type):
         qml.sample(qml.Hadamard(0) @ qml.Identity(1))
         qml.sample(qml.Hermitian(np.array([[0, 1], [1, 0]]), wires=[2]))
 
-    if old_return_type:
-        qml.disable_return()
     results = dev.execute(circuit)
-    qml.enable_return()
 
     assert len(results) == 2
     assert results[0].shape == (4,)
     assert results[1].shape == (4,)
 
 
-@pytest.mark.parametrize("old_return_type", [True, False])
 @patch.object(AwsDevice, "run")
-def test_execute_some_samples(mock_run, old_return_type):
+def test_execute_some_samples(mock_run):
     """Tests that a combination with sample returns correctly and does not put single-number
     results in superflous arrays"""
     result = GateModelQuantumTaskResult.from_string(
@@ -1320,8 +1315,6 @@ def test_execute_some_samples(mock_run, old_return_type):
             }
         )
     )
-    if old_return_type:
-        qml.disable_return()
     task = Mock()
     task.result.return_value = result
     mock_run.return_value = task
@@ -1334,7 +1327,6 @@ def test_execute_some_samples(mock_run, old_return_type):
         qml.expval(qml.PauliZ(2))
 
     results = dev.execute(circuit)
-    qml.enable_return()
 
     assert len(results) == 2
     assert results[0].shape == (4,)
@@ -1543,7 +1535,6 @@ def test_add_braket_user_agent_invoked(aws_device_mock):
 
 
 @patch.object(AwsDevice, "run")
-@pytest.mark.parametrize("old_return_type", [True, False])
 @pytest.mark.parametrize(
     "pl_circ, expected_braket_circ, wires, expected_inputs, result_types, expected_pl_result",
     [
@@ -1628,10 +1619,7 @@ def test_execute_and_gradients(
     expected_inputs,
     result_types,
     expected_pl_result,
-    old_return_type,
 ):
-    if old_return_type:
-        qml.disable_return()
     task = Mock()
     type(task).id = PropertyMock(return_value="task_arn")
     task.state.return_value = "COMPLETED"
@@ -1646,7 +1634,6 @@ def test_execute_and_gradients(
     )
 
     results, jacs = dev.execute_and_gradients([pl_circ])
-    qml.enable_return()
 
     assert dev.task == task
     mock_run.assert_called_with(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

PennyLane master branch for v0.33 has removed the legacy return types system.  `qml.active_return()`, `qml.enable_return()` and `qml.disable_return()` no longer exist.  This causes failures with the braket plugin and master PennyLane that will be released on October 31.

This PR removes references to `active_return`, `enable_return`, and `disable_return`.

*Testing done:*
 
Unit tests pass locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[sc-46642]