### PR TITLE
depr: Remove legacy return types system

### DIFF
--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -745,10 +745,10 @@ class BraketAwsQubitDevice(BraketQubitDevice):
             else:
                 results = self.execute(circuit, compute_gradient=True)
                 new_res, new_jac = results
+                new_res = new_res[0]
                 new_jac = self._adjoint_jacobian_processing(new_jac)
             res.append(new_res)
             jacs.append(new_jac)
-        res = res[0] if len(res) == 1 else res
         return res, jacs
 
 

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -745,6 +745,8 @@ class BraketAwsQubitDevice(BraketQubitDevice):
             else:
                 results = self.execute(circuit, compute_gradient=True)
                 new_res, new_jac = results
+                # PennyLane expects the forward execution result to be a scalar
+                # when it is accompanied by an adjoint gradient calculation
                 new_res = new_res[0]
                 new_jac = self._adjoint_jacobian_processing(new_jac)
             res.append(new_res)


### PR DESCRIPTION
Note: the legacy return types system was actually removed in #210; the commit is named as is to force a minor version change, since this is a deprecation.

This change fixes the legacy return types removal by only converting the forward execution result to a scalar for adjoint gradient computations. This was also the case prior to #210, but the recent change ended up doing this conversion for _all_ forward executions. 

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.