### PR TITLE
fix: set the isort profile to black

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ testpaths = test/unit_tests
 line_length = 100
 multi_line_output = 3
 include_trailing_comma = true
+profile = black
 
 [flake8]
 ignore =


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This avoids the two tools (isort and black) from trampling on each other. https://pycqa.github.io/isort/docs/configuration/black_compatibility.html

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.