### PR TITLE
test: Mock only service call in AHS device initialization

### DIFF
--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -1318,6 +1318,7 @@ class TestBraketAwsAhsDevice:
     def test_run_task(self, mock_aws_device):
         """Tests that a (mock) task can be created"""
         dev = mock_aws_device()
+        dev._device._noise_model = None
         ahs_program = dummy_ahs_program()
 
         task = dev._run_task(ahs_program)

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -15,7 +15,6 @@
 import json
 from dataclasses import dataclass
 from functools import partial
-from unittest import mock
 from unittest.mock import Mock
 
 import numpy as np
@@ -233,9 +232,9 @@ class MockDevProperties:
 def mock_aws_device(monkeypatch, wires=3):
     """A function to create a mock device that mocks most of the methods"""
     with monkeypatch.context() as m:
-        m.setattr(AwsDevice, "__init__", lambda self, *args, **kwargs: None)
-        m.setattr(AwsDevice, "aws_session", MockAwsSession)
-        m.setattr(AwsDevice, "type", mock.PropertyMock)
+        m.setattr(
+            AwsDevice, "_get_session_and_initialize", lambda self, *args, **kwargs: MockAwsSession
+        )
         m.setattr(AwsDevice, "properties", MockDevProperties)
 
         def get_aws_device(
@@ -1318,7 +1317,6 @@ class TestBraketAwsAhsDevice:
     def test_run_task(self, mock_aws_device):
         """Tests that a (mock) task can be created"""
         dev = mock_aws_device()
-        dev._device._noise_model = None
         ahs_program = dummy_ahs_program()
 
         task = dev._run_task(ahs_program)


### PR DESCRIPTION
*Description of changes:*
Add noise model to mock aws device in unit test. This is an update for introducing BDK PR https://github.com/amazon-braket/amazon-braket-sdk-python/pull/850

*Testing done:*
tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.