### PR TITLE
fix: move to use measurementprocess.obs.name

### DIFF
--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -262,7 +262,7 @@ class BraketQubitDevice(QubitDevice):
         for mp in measurements:
             if mp.return_type not in RETURN_TYPES:
                 raise QuantumFunctionError(
-                    "Unsupported return type specified for observable {}".format(mp.name)
+                    "Unsupported return type specified for observable {}".format(mp.obs.name)
                 )
             results.append(self._get_statistic(braket_result, mp))
         return results


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes: 

```
test/unit_tests/test_braket_device.py::test_bad_statistics
  /opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pennylane/measurements/measurements.py:196: PennyLaneDeprecationWarning: MeasurementProcess.name is deprecated, and will be removed in an upcoming release. To get the name of an observable from a measurement, use MeasurementProcess.obs.name instead
```

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.