### PR TITLE
fix: cnot gate gets properly decomposed so catch proper test error

### DIFF
--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -558,7 +558,7 @@ class TestBraketAhsDevice:
         dev = qml.device("braket.local.ahs", wires=3)
 
         with pytest.raises(
-            RuntimeError, match="with no diagonalizing gates; cannot determine basis"
+            RuntimeError, match="can only measure in the Z basis, but received observable"
         ):
             dev._validate_measurement_basis(qml.CNOT([0, 1]))
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
https://github.com/PennyLaneAI/pennylane/blob/cb6f1cdb8cda09eae9113284eb12b9dde18544a2/doc/releases/changelog-0.35.0.md?plain=1#L612

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.