### PR TITLE
fix: update test to use DummyOp

### DIFF
--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -557,10 +557,17 @@ class TestBraketAhsDevice:
 
         dev = qml.device("braket.local.ahs", wires=3)
 
+        # DummyOp will continue having undefined diagonalizing gates as PL expands functionality
+        class DummyOp(qml.operation.Operator):
+            pass
+
+        with pytest.raises(qml.operation.DiagGatesUndefinedError):
+            DummyOp([0, 1]).diagonalizing_gates()
+
         with pytest.raises(
             RuntimeError, match="with no diagonalizing gates; cannot determine basis"
         ):
-            dev._validate_measurement_basis(qml.CNOT([0, 1]))
+            dev._validate_measurement_basis(DummyOp([0, 1]))
 
     @pytest.mark.parametrize(
         "observable, error_expected",


### PR DESCRIPTION
*Description of changes:*
A test for how the AHS device handles operators with undefined diagonalizing gates is failing because it uses `CNOT`, which now does have a definition for diagonalizing gates in PennyLane 0.35.

We update the test to use a `DummyOp` created in the test, that should continue to have undefined diagonalizing gates.