### PR TITLE
feature: support Prod as an observable

### DIFF
--- a/src/braket/pennylane_plugin/translation.py
+++ b/src/braket/pennylane_plugin/translation.py
@@ -646,6 +646,11 @@ def _(t: qml.operation.Tensor):
     return reduce(lambda x, y: x @ y, [_translate_observable(factor) for factor in t.obs])
 
 
+@_translate_observable.register
+def _(t: qml.ops.Prod):
+    return reduce(lambda x, y: x @ y, [_translate_observable(factor) for factor in t.operands])
+
+
 def translate_result(
     braket_result: GateModelQuantumTaskResult,
     measurement: MeasurementProcess,

--- a/test/unit_tests/test_translation.py
+++ b/test/unit_tests/test_translation.py
@@ -845,6 +845,7 @@ def _result_meta() -> dict:
             + 0.75 * qml.PauliX(0),
         ),
         (1.25 * observables.H(), 1.25 * qml.Hadamard(wires=0)),
+        (observables.X() @ observables.Y(), qml.ops.Prod(qml.PauliX(0), qml.PauliY(1))),
     ],
 )
 def test_translate_hamiltonian_observable(expected_braket_H, pl_H):


### PR DESCRIPTION
*Issue #, if available:*
#241 

*Description of changes:*

Add support for `Prod` since Observables made with @ will now be instances of `Prod` instead of `Tensor` in the newest version of PennyLane (0.36.0)

*Testing done:*
`tox` and `tox -e integ-tests`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.