### PR TITLE
feature: support LinearCombination as observable

### DIFF
--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -37,22 +37,14 @@ from enum import Enum, auto
 from typing import Optional, Union
 
 import numpy as np
+import pennylane as qml
 from braket.ahs.analog_hamiltonian_simulation import AnalogHamiltonianSimulation
 from braket.aws import AwsDevice, AwsQuantumTask, AwsSession
 from braket.devices import Device, LocalSimulator
 from pennylane import QubitDevice
 from pennylane._version import __version__
 from pennylane.measurements import MeasurementProcess, SampleMeasurement
-from pennylane.ops import CompositeOp, Hamiltonian
-
-try:
-    from pennylane.ops import LinearCombination
-except (AttributeError, ImportError):
-
-    class LinearCombination:
-        pass
-
-
+from pennylane.ops import CompositeOp
 from pennylane.pulse import ParametrizedEvolution
 from pennylane.pulse.hardware_hamiltonian import HardwareHamiltonian, HardwarePulse
 
@@ -317,7 +309,7 @@ class BraketAhsDevice(QubitDevice):
         if isinstance(observable, CompositeOp):
             for op in observable.operands:
                 self._validate_measurement_basis(op)
-        elif isinstance(observable, (Hamiltonian, LinearCombination)):
+        elif isinstance(observable, (qml.ops.Hamiltonian, qml.Hamiltonian)):
             for op in observable.ops:
                 self._validate_measurement_basis(op)
 

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -44,6 +44,15 @@ from pennylane import QubitDevice
 from pennylane._version import __version__
 from pennylane.measurements import MeasurementProcess, SampleMeasurement
 from pennylane.ops import CompositeOp, Hamiltonian
+
+try:
+    from pennylane.ops import LinearCombination
+except (AttributeError, ImportError):
+
+    class LinearCombination:
+        pass
+
+
 from pennylane.pulse import ParametrizedEvolution
 from pennylane.pulse.hardware_hamiltonian import HardwareHamiltonian, HardwarePulse
 
@@ -308,7 +317,7 @@ class BraketAhsDevice(QubitDevice):
         if isinstance(observable, CompositeOp):
             for op in observable.operands:
                 self._validate_measurement_basis(op)
-        elif isinstance(observable, Hamiltonian):
+        elif isinstance(observable, (Hamiltonian, LinearCombination)):
             for op in observable.ops:
                 self._validate_measurement_basis(op)
 

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -44,7 +44,7 @@ from braket.devices import Device, LocalSimulator
 from pennylane import QubitDevice
 from pennylane._version import __version__
 from pennylane.measurements import MeasurementProcess, SampleMeasurement
-from pennylane.ops import CompositeOp
+from pennylane.ops import CompositeOp, Hamiltonian
 from pennylane.pulse import ParametrizedEvolution
 from pennylane.pulse.hardware_hamiltonian import HardwareHamiltonian, HardwarePulse
 
@@ -309,7 +309,7 @@ class BraketAhsDevice(QubitDevice):
         if isinstance(observable, CompositeOp):
             for op in observable.operands:
                 self._validate_measurement_basis(op)
-        elif isinstance(observable, (qml.ops.Hamiltonian, qml.Hamiltonian)):
+        elif isinstance(observable, (Hamiltonian, qml.Hamiltonian)):
             for op in observable.ops:
                 self._validate_measurement_basis(op)
 

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -67,14 +67,6 @@ from pennylane.measurements import (
 from pennylane.operation import Operation
 from pennylane.tape import QuantumTape
 
-try:
-    from pennylane.ops import LinearCombination
-except (AttributeError, ImportError):
-
-    class LinearCombination:
-        pass
-
-
 from braket.pennylane_plugin.translation import (
     get_adjoint_gradient_result_type,
     supported_operations,
@@ -234,7 +226,7 @@ class BraketQubitDevice(QubitDevice):
                 f"Braket can only compute gradients for circuits with a single expectation"
                 f" observable, not a {pl_measurements.return_type} observable."
             )
-        if isinstance(pl_observable, (qml.ops.Hamiltonian, LinearCombination)):
+        if isinstance(pl_observable, (qml.ops.Hamiltonian, qml.Hamiltonian)):
             targets = [self.map_wires(op.wires) for op in pl_observable.ops]
         else:
             targets = self.map_wires(pl_observable.wires).tolist()

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -65,6 +65,7 @@ from pennylane.measurements import (
     Variance,
 )
 from pennylane.operation import Operation
+from pennylane.ops import Hamiltonian
 from pennylane.tape import QuantumTape
 
 from braket.pennylane_plugin.translation import (
@@ -226,7 +227,7 @@ class BraketQubitDevice(QubitDevice):
                 f"Braket can only compute gradients for circuits with a single expectation"
                 f" observable, not a {pl_measurements.return_type} observable."
             )
-        if isinstance(pl_observable, (qml.ops.Hamiltonian, qml.Hamiltonian)):
+        if isinstance(pl_observable, (Hamiltonian, qml.Hamiltonian)):
             targets = [self.map_wires(op.wires) for op in pl_observable.ops]
         else:
             targets = self.map_wires(pl_observable.wires).tolist()

--- a/src/braket/pennylane_plugin/translation.py
+++ b/src/braket/pennylane_plugin/translation.py
@@ -33,7 +33,7 @@ from braket.tasks import GateModelQuantumTaskResult
 from pennylane import numpy as np
 from pennylane.measurements import MeasurementProcess, ObservableReturnTypes
 from pennylane.operation import Observable, Operation
-from pennylane.ops import Adjoint
+from pennylane.ops import Adjoint, Hamiltonian
 from pennylane.pulse import ParametrizedEvolution
 
 from braket.pennylane_plugin.ops import (
@@ -558,7 +558,7 @@ def translate_result_type(
             return DensityMatrix(targets)
         raise NotImplementedError(f"Unsupported return type: {return_type}")
 
-    if isinstance(measurement.obs, (qml.ops.Hamiltonian, qml.Hamiltonian)):
+    if isinstance(measurement.obs, (Hamiltonian, qml.Hamiltonian)):
         if return_type is ObservableReturnTypes.Expectation:
             return tuple(
                 Expectation(_translate_observable(term), term.wires) for term in measurement.obs.ops
@@ -581,9 +581,9 @@ def _translate_observable(observable):
     raise qml.DeviceError(f"Unsupported observable: {type(observable)}")
 
 
-@_translate_observable.register(qml.ops.Hamiltonian)
+@_translate_observable.register(Hamiltonian)
 @_translate_observable.register(qml.Hamiltonian)
-def _(H: Union[qml.ops.Hamiltonian, qml.Hamiltonian]):
+def _(H: Union[Hamiltonian, qml.Hamiltonian]):
     # terms is structured like [C, O] where C is a tuple of all the coefficients, and O is
     # a tuple of all the corresponding observable terms (X, Y, Z, H, etc or a tensor product
     # of them)
@@ -699,7 +699,7 @@ def translate_result(
             for i in sorted(key_indices)
         ]
     translated = translate_result_type(measurement, targets, supported_result_types)
-    if isinstance(observable, (qml.ops.Hamiltonian, qml.Hamiltonian)):
+    if isinstance(observable, (Hamiltonian, qml.Hamiltonian)):
         coeffs, _ = observable.terms()
         return sum(
             coeff * braket_result.get_value_by_result_type(result_type)

--- a/src/braket/pennylane_plugin/translation.py
+++ b/src/braket/pennylane_plugin/translation.py
@@ -34,6 +34,15 @@ from pennylane import numpy as np
 from pennylane.measurements import MeasurementProcess, ObservableReturnTypes
 from pennylane.operation import Observable, Operation
 from pennylane.ops import Adjoint
+
+try:
+    from pennylane.ops import LinearCombination
+except (AttributeError, ImportError):
+
+    class LinearCombination:
+        pass
+
+
 from pennylane.pulse import ParametrizedEvolution
 
 from braket.pennylane_plugin.ops import (
@@ -558,7 +567,7 @@ def translate_result_type(
             return DensityMatrix(targets)
         raise NotImplementedError(f"Unsupported return type: {return_type}")
 
-    if isinstance(measurement.obs, qml.Hamiltonian):
+    if isinstance(measurement.obs, (qml.ops.Hamiltonian, LinearCombination)):
         if return_type is ObservableReturnTypes.Expectation:
             return tuple(
                 Expectation(_translate_observable(term), term.wires) for term in measurement.obs.ops
@@ -581,8 +590,9 @@ def _translate_observable(observable):
     raise qml.DeviceError(f"Unsupported observable: {type(observable)}")
 
 
-@_translate_observable.register
-def _(H: qml.Hamiltonian):
+@_translate_observable.register(qml.ops.Hamiltonian)
+@_translate_observable.register(LinearCombination)
+def _(H: Union[qml.ops.Hamiltonian, LinearCombination]):
     # terms is structured like [C, O] where C is a tuple of all the coefficients, and O is
     # a tuple of all the corresponding observable terms (X, Y, Z, H, etc or a tensor product
     # of them)
@@ -651,6 +661,16 @@ def _(t: qml.ops.Prod):
     return reduce(lambda x, y: x @ y, [_translate_observable(factor) for factor in t.operands])
 
 
+@_translate_observable.register
+def _(t: qml.ops.SProd):
+    return t.scalar * _translate_observable(t.base)
+
+
+@_translate_observable.register
+def _(t: qml.ops.Sum):
+    return reduce(lambda x, y: x + y, [_translate_observable(operator) for operator in t.operands])
+
+
 def translate_result(
     braket_result: GateModelQuantumTaskResult,
     measurement: MeasurementProcess,
@@ -688,7 +708,7 @@ def translate_result(
             for i in sorted(key_indices)
         ]
     translated = translate_result_type(measurement, targets, supported_result_types)
-    if isinstance(observable, qml.Hamiltonian):
+    if isinstance(observable, (qml.ops.Hamiltonian, LinearCombination)):
         coeffs, _ = observable.terms()
         return sum(
             coeff * braket_result.get_value_by_result_type(result_type)

--- a/src/braket/pennylane_plugin/translation.py
+++ b/src/braket/pennylane_plugin/translation.py
@@ -34,15 +34,6 @@ from pennylane import numpy as np
 from pennylane.measurements import MeasurementProcess, ObservableReturnTypes
 from pennylane.operation import Observable, Operation
 from pennylane.ops import Adjoint
-
-try:
-    from pennylane.ops import LinearCombination
-except (AttributeError, ImportError):
-
-    class LinearCombination:
-        pass
-
-
 from pennylane.pulse import ParametrizedEvolution
 
 from braket.pennylane_plugin.ops import (
@@ -567,7 +558,7 @@ def translate_result_type(
             return DensityMatrix(targets)
         raise NotImplementedError(f"Unsupported return type: {return_type}")
 
-    if isinstance(measurement.obs, (qml.ops.Hamiltonian, LinearCombination)):
+    if isinstance(measurement.obs, (qml.ops.Hamiltonian, qml.Hamiltonian)):
         if return_type is ObservableReturnTypes.Expectation:
             return tuple(
                 Expectation(_translate_observable(term), term.wires) for term in measurement.obs.ops
@@ -591,8 +582,8 @@ def _translate_observable(observable):
 
 
 @_translate_observable.register(qml.ops.Hamiltonian)
-@_translate_observable.register(LinearCombination)
-def _(H: Union[qml.ops.Hamiltonian, LinearCombination]):
+@_translate_observable.register(qml.Hamiltonian)
+def _(H: Union[qml.ops.Hamiltonian, qml.Hamiltonian]):
     # terms is structured like [C, O] where C is a tuple of all the coefficients, and O is
     # a tuple of all the corresponding observable terms (X, Y, Z, H, etc or a tensor product
     # of them)
@@ -708,7 +699,7 @@ def translate_result(
             for i in sorted(key_indices)
         ]
     translated = translate_result_type(measurement, targets, supported_result_types)
-    if isinstance(observable, (qml.ops.Hamiltonian, LinearCombination)):
+    if isinstance(observable, (qml.ops.Hamiltonian, qml.Hamiltonian)):
         coeffs, _ = observable.terms()
         return sum(
             coeff * braket_result.get_value_by_result_type(result_type)

--- a/test/unit_tests/test_translation.py
+++ b/test/unit_tests/test_translation.py
@@ -846,6 +846,8 @@ def _result_meta() -> dict:
         ),
         (1.25 * observables.H(), 1.25 * qml.Hadamard(wires=0)),
         (observables.X() @ observables.Y(), qml.ops.Prod(qml.PauliX(0), qml.PauliY(1))),
+        (observables.X() + observables.Y(), qml.ops.Sum(qml.PauliX(0), qml.PauliY(1))),
+        (observables.X(), qml.ops.SProd(scalar=4, base=qml.PauliX(0))),
     ],
 )
 def test_translate_hamiltonian_observable(expected_braket_H, pl_H):


### PR DESCRIPTION
*Issue #, if available:*
#245 

*Description of changes:*
- Add support for the new `LinearCombination` as an observable that will be the default in the new version of PennyLane
- Add support for the `qml.opsSProd` and `qml.ops.Sum` in the observable

*Testing done:*
`tox` and `tox -e integ-tests`
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.