### PR TITLE
fix: Translate `Sum` for adjoint gradient

### DIFF
--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -65,7 +65,7 @@ from pennylane.measurements import (
     Variance,
 )
 from pennylane.operation import Operation
-from pennylane.ops import Hamiltonian
+from pennylane.ops import Hamiltonian, Sum
 from pennylane.tape import QuantumTape
 
 from braket.pennylane_plugin.translation import (
@@ -162,7 +162,7 @@ class BraketQubitDevice(QubitDevice):
 
     @property
     def observables(self) -> frozenset[str]:
-        base_observables = frozenset(super().observables - {"SProd", "Sum"})
+        base_observables = frozenset(super().observables)
         # Amazon Braket only supports coefficients and multiple terms when shots==0
         if not self.shots:
             return base_observables.union({"Hamiltonian", "LinearCombination"})
@@ -226,8 +226,8 @@ class BraketQubitDevice(QubitDevice):
                 f"Braket can only compute gradients for circuits with a single expectation"
                 f" observable, not a {pl_measurements.return_type} observable."
             )
-        if isinstance(pl_observable, (Hamiltonian, qml.Hamiltonian)):
-            targets = [self.map_wires(op.wires) for op in pl_observable.ops]
+        if isinstance(pl_observable, (Hamiltonian, qml.Hamiltonian, Sum)):
+            targets = [self.map_wires(op.wires) for op in pl_observable.terms()[1]]
         else:
             targets = self.map_wires(pl_observable.wires).tolist()
 

--- a/src/braket/pennylane_plugin/ops.py
+++ b/src/braket/pennylane_plugin/ops.py
@@ -29,10 +29,12 @@ These operations can be imported via
         CPhaseShift00,
         CPhaseShift01,
         CPhaseShift10,
+        PRx,
         PSWAP,
         GPi,
         GPi2,
         MS,
+        AAMS,
     )
 
 Operations
@@ -42,10 +44,12 @@ Operations
     CPhaseShift00
     CPhaseShift01
     CPhaseShift10
+    PRx
     PSWAP
     GPi
     GPi2
     MS
+    AAMS
 
 Code details
 ~~~~~~~~~~~~

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -440,6 +440,25 @@ class TestBraketAhsDevice:
         dev.check_validity(ops, obs)
 
     @pytest.mark.parametrize("H, params", HAMILTONIANS_AND_PARAMS)
+    def test_check_validity_valid_circuit_no_op_math(self, H, params):
+        """Tests that check_validity() doesn't raise any errors when the operations and
+        observables are valid."""
+        qml.operation.disable_new_opmath()
+        ops = [ParametrizedEvolution(H, params, [0, 1.5])]
+        obs = [
+            qml.PauliZ(0),
+            qml.expval(qml.PauliZ(0)),
+            qml.var(qml.Identity(0)),
+            qml.sample(qml.PauliZ(0)),
+            qml.prod(qml.PauliZ(0), qml.Identity(1)),
+            qml.Hamiltonian([2, 3], [qml.PauliZ(0), qml.PauliZ(1)]),
+            qml.counts(),
+        ]
+        dev = qml.device("braket.local.ahs", wires=3)
+
+        dev.check_validity(ops, obs)
+
+    @pytest.mark.parametrize("H, params", HAMILTONIANS_AND_PARAMS)
     def test_check_validity_raises_error_for_state_based_measurement(self, H, params):
         """Tests that requesting a measurement other than a sample-based
         measurement raises an error"""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The plugin only translates `Hamiltonian`s for the adjoint gradient, but Hamiltonians are often actually `Sum` objects. This change adds `Sum` observable translation.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.