### PR TITLE
Remove deprecated import path for QubitDevice

### DIFF
--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -39,8 +39,8 @@ from typing import Optional, Union
 
 import numpy as np
 import pennylane as qml
-from pennylane import QubitDevice
 from pennylane._version import __version__
+from pennylane.devices import QubitDevice
 from pennylane.measurements import MeasurementProcess, SampleMeasurement
 from pennylane.ops import CompositeOp, Hamiltonian
 from pennylane.pulse import ParametrizedEvolution

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -44,8 +44,9 @@ from typing import Optional, Union
 
 import numpy as onp
 import pennylane as qml
-from pennylane import QuantumFunctionError, QubitDevice
+from pennylane import QuantumFunctionError
 from pennylane import numpy as np
+from pennylane.devices import QubitDevice
 from pennylane.gradients import param_shift
 from pennylane.measurements import (
     Counts,

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -53,8 +53,9 @@ from device_property_jsons import (
     OQC_PULSE_PROPERTIES_ALL_FRAMES,
     RESULT,
 )
-from pennylane import QuantumFunctionError, QubitDevice
+from pennylane import QuantumFunctionError
 from pennylane import numpy as np
+from pennylane.devices import QubitDevice
 from pennylane.pulse import ParametrizedEvolution
 from pennylane.tape import QuantumScript, QuantumTape
 


### PR DESCRIPTION
*Description of changes:*

The `QubitDevice` class is no longer accessible via the top level of PennyLane (see https://github.com/PennyLaneAI/pennylane/pull/6537)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.