### PR TITLE
depr: remove legacy opmath

### DIFF
--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -38,7 +38,6 @@ from enum import Enum, auto
 from typing import Optional, Union
 
 import numpy as np
-import pennylane as qml
 from pennylane._version import __version__
 from pennylane.devices import QubitDevice
 from pennylane.measurements import MeasurementProcess, SampleMeasurement

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -42,7 +42,7 @@ import pennylane as qml
 from pennylane._version import __version__
 from pennylane.devices import QubitDevice
 from pennylane.measurements import MeasurementProcess, SampleMeasurement
-from pennylane.ops import CompositeOp, Hamiltonian
+from pennylane.ops import CompositeOp
 from pennylane.pulse import ParametrizedEvolution
 from pennylane.pulse.hardware_hamiltonian import HardwareHamiltonian, HardwarePulse
 
@@ -311,9 +311,6 @@ class BraketAhsDevice(QubitDevice):
         # loop through those and evaluate individually
         if isinstance(observable, CompositeOp):
             for op in observable.operands:
-                self._validate_measurement_basis(op)
-        elif isinstance(observable, (Hamiltonian, qml.Hamiltonian)):
-            for op in observable.ops:
                 self._validate_measurement_basis(op)
 
         elif not observable.has_diagonalizing_gates:

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -60,7 +60,7 @@ from pennylane.measurements import (
     Variance,
 )
 from pennylane.operation import Operation
-from pennylane.ops import Hamiltonian, Sum
+from pennylane.ops import Sum
 from pennylane.tape import QuantumTape
 
 from braket.aws import (
@@ -287,7 +287,7 @@ class BraketQubitDevice(QubitDevice):
                 f"Braket can only compute gradients for circuits with a single expectation"
                 f" observable, not a {pl_measurements.return_type} observable."
             )
-        if isinstance(pl_observable, (Hamiltonian, Sum)):
+        if isinstance(pl_observable, Sum):
             targets = [self.map_wires(op.wires) for op in pl_observable.terms()[1]]
         else:
             targets = self.map_wires(pl_observable.wires).tolist()

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -468,25 +468,6 @@ class TestBraketAhsDevice:
         dev.check_validity(ops, obs)
 
     @pytest.mark.parametrize("H, params", HAMILTONIANS_AND_PARAMS)
-    def test_check_validity_valid_circuit_no_op_math(self, H, params):
-        """Tests that check_validity() doesn't raise any errors when the operations and
-        observables are valid."""
-        qml.operation.disable_new_opmath()
-        ops = [ParametrizedEvolution(H, params, [0, 1.5])]
-        obs = [
-            qml.PauliZ(0),
-            qml.expval(qml.PauliZ(0)),
-            qml.var(qml.Identity(0)),
-            qml.sample(qml.PauliZ(0)),
-            qml.prod(qml.PauliZ(0), qml.Identity(1)),
-            qml.Hamiltonian([2, 3], [qml.PauliZ(0), qml.PauliZ(1)]),
-            qml.counts(),
-        ]
-        dev = qml.device("braket.local.ahs", wires=3)
-
-        dev.check_validity(ops, obs)
-
-    @pytest.mark.parametrize("H, params", HAMILTONIANS_AND_PARAMS)
     def test_check_validity_raises_error_for_state_based_measurement(self, H, params):
         """Tests that requesting a measurement other than a sample-based
         measurement raises an error"""

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -569,7 +569,6 @@ def test_execute_with_gradient_no_op_math(
     result_types,
     expected_pl_result,
 ):
-    qml.operation.disable_new_opmath()
 
     task = Mock()
     type(task).id = PropertyMock(return_value="task_arn")
@@ -830,8 +829,8 @@ def test_pl_to_braket_circuit_hamiltonian():
 
 
 def test_pl_to_braket_circuit_hamiltonian_tensor_product_terms():
-    """Tests that a PennyLane circuit is correctly converted into a Braket circuit"""
-    """when the Hamiltonian has multiple tensor product ops"""
+    """Tests that a PennyLane circuit is correctly converted into a Braket circuit
+    when the Hamiltonian has multiple tensor product ops"""
     dev = _aws_device(wires=2, foo="bar")
 
     with QuantumTape() as tape:
@@ -1313,6 +1312,8 @@ def test_execute_some_samples(mock_run):
     task.result.return_value = result
     mock_run.return_value = task
     dev = _aws_device(wires=3)
+
+    print(type(qml.Hadamard(0) @ qml.Identity(1)))
 
     with QuantumTape() as circuit:
         qml.Hadamard(wires=0)

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -1313,8 +1313,6 @@ def test_execute_some_samples(mock_run):
     mock_run.return_value = task
     dev = _aws_device(wires=3)
 
-    print(type(qml.Hadamard(0) @ qml.Identity(1)))
-
     with QuantumTape() as circuit:
         qml.Hadamard(wires=0)
         qml.CNOT(wires=[0, 1])

--- a/test/unit_tests/test_translation.py
+++ b/test/unit_tests/test_translation.py
@@ -749,7 +749,7 @@ def test_translate_result_type_hamiltonian_unsupported_return(return_type):
     with Hamiltonian observable and non-Expectation return type"""
     obs = qml.Hamiltonian((2, 3), (qml.PauliX(wires=0), qml.PauliY(wires=1)))
     tape = qml.tape.QuantumTape(measurements=[_braket_to_pl_result_types[return_type](obs)])
-    with pytest.raises(NotImplementedError, match="unsupported for Hamiltonian"):
+    with pytest.raises(NotImplementedError, match="unsupported for LinearCombination"):
         translate_result_type(tape.measurements[0], [0], frozenset())
 
 


### PR DESCRIPTION
*Description of changes:*
PennyLane has removed support for legacy operator arithmetic (Hamiltonian, Tensor). These will part of the upcoming release.

*Testing done:*
Removed tests referring to legacy operator arithmetic. No additional tests needed - we are removing support.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.