### PR TITLE
Remove use of `MeasurementProcess.return_type`

### DIFF
--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -210,7 +210,7 @@ class BraketAhsDevice(QubitDevice):
         Args:
             queue (Iterable[~.operation.Operation]): quantum operation objects which are intended
                 to be applied on the device
-            observables (Iterable[~.operation.Observable]): observables which are intended
+            observables (Iterable[~.operation.Operator]): observables which are intended
                 to be evaluated on the device
 
         Raises:

--- a/src/braket/pennylane_plugin/translation.py
+++ b/src/braket/pennylane_plugin/translation.py
@@ -18,8 +18,8 @@ from typing import Any, Optional, Union
 import numpy as onp
 import pennylane as qml
 from pennylane import numpy as np
-from pennylane.measurements import MeasurementProcess, ObservableReturnTypes
-from pennylane.operation import Observable, Operation
+from pennylane.measurements import MeasurementProcess
+from pennylane.operation import Operator, Operation
 from pennylane.pulse import ParametrizedEvolution
 
 from braket.aws import AwsDevice
@@ -538,7 +538,7 @@ def supported_observables(device: Device, shots: int) -> frozenset[str]:
 
 
 def get_adjoint_gradient_result_type(
-    observable: Observable,
+    observable: Operator,
     targets: Union[list[int], list[list[int]]],
     supported_result_types: frozenset[str],
     parameters: list[str],
@@ -571,41 +571,41 @@ def translate_result_type(  # noqa: C901
         the given observable; if the observable type has multiple terms, for example a Sum,
         then this will return a result type for each term.
     """
-    return_type = measurement.return_type
     targets = targets or measurement.wires.tolist()
     observable = measurement.obs
 
-    if return_type is ObservableReturnTypes.Probability:
+    if isinstance(measurement, qml.measurements.ProbabilityMP):
         return Probability(targets)
 
-    if return_type is ObservableReturnTypes.State:
+    if isinstance(measurement, qml.measurements.StateMP):
         if not targets and "StateVector" in supported_result_types:
             return StateVector()
         elif "DensityMatrix" in supported_result_types:
             return DensityMatrix(targets)
-        raise NotImplementedError(f"Unsupported return type: {return_type}")
+        raise NotImplementedError(f"Unsupported return type: {type(measurement)}")
 
     if observable is None:
-        if return_type is ObservableReturnTypes.Counts:
+        if isinstance(measurement, qml.measurements.CountsMP) and not measurement.all_outcomes:
             return tuple(Sample(observables.Z(target)) for target in targets or measurement.wires)
-        raise NotImplementedError(f"Unsupported return type: {return_type}")
+        raise NotImplementedError(f"Unsupported return type: {type(measurement)}")
 
     observable = flatten_observable(observable)
 
     if isinstance(observable, qml.ops.LinearCombination):
-        if return_type is ObservableReturnTypes.Expectation:
+        if isinstance(measurement, qml.measurements.ExpectationMP):
             return tuple(Expectation(_translate_observable(op)) for op in observable.terms()[1])
-        raise NotImplementedError(f"Return type {return_type} unsupported for LinearCombination")
+        raise NotImplementedError(f"Return type {type(measurement)} unsupported for LinearCombination")
 
     braket_observable = _translate_observable(observable)
-    if return_type is ObservableReturnTypes.Expectation:
+    if isinstance(measurement, qml.measurements.ExpectationMP):
         return Expectation(braket_observable)
-    elif return_type is ObservableReturnTypes.Variance:
+    if isinstance(measurement, qml.measurements.VarianceMP):
         return Variance(braket_observable)
-    elif return_type in (ObservableReturnTypes.Sample, ObservableReturnTypes.Counts):
+    if isinstance(measurement, qml.measurements.CountsMP) and not measurement.all_outcomes:
         return Sample(braket_observable)
-    else:
-        raise NotImplementedError(f"Unsupported return type: {return_type}")
+    if isinstance(measurement, qml.measurements.SampleMP):
+        return Sample(braket_observable)
+    raise NotImplementedError(f"Unsupported return type: {type(measurement)}")
 
 
 def flatten_observable(observable):
@@ -722,7 +722,7 @@ def translate_result(
         ]
 
     targets = targets or measurement.wires.tolist()
-    if measurement.return_type is ObservableReturnTypes.Counts and observable is None:
+    if isinstance(measurement, qml.measurements.CountsMP) and not measurement.all_outcomes and observable is None:
         if targets:
             new_dict = {}
             for key, value in braket_result.measurement_counts.items():
@@ -742,7 +742,7 @@ def translate_result(
             coeff * braket_result.get_value_by_result_type(result_type)
             for coeff, result_type in zip(coeffs, translated)
         )
-    elif measurement.return_type is ObservableReturnTypes.Counts:
+    elif isinstance(measurement, qml.measurements.CountsMP) and not measurement.all_outcomes:
         return dict(Counter(braket_result.get_value_by_result_type(translated)))
     else:
         return braket_result.get_value_by_result_type(translated)

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -646,7 +646,7 @@ class TestBraketAhsDevice:
         ],
     )
     def test_validate_measurement_basis(self, observable, error_expected):
-        """Tests that when given an Observable not in the Z basis, _validate_measurement_basis,
+        """Tests that when given an Operator not in the Z basis, _validate_measurement_basis,
         fails with an error, but otherwise passes"""
 
         dev = qml.device("braket.local.ahs", wires=3)

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -1467,7 +1467,7 @@ def test_counts_all_outcomes_fails():
         qml.CNOT(wires=[0, 1])
         qml.counts(all_outcomes=True)
 
-    does_not_support = "Unsupported return type: ObservableReturnTypes.AllCounts"
+    does_not_support = "Unsupported return type: <class 'pennylane.measurements.counts.CountsMP'>"
     with pytest.raises(NotImplementedError, match=does_not_support):
         dev.execute(circuit)
 
@@ -1481,7 +1481,7 @@ def test_sample_fails():
         qml.CNOT(wires=[0, 1])
         qml.sample()
 
-    does_not_support = "Unsupported return type: ObservableReturnTypes.Sample"
+    does_not_support = "Unsupported return type: <class 'pennylane.measurements.sample.SampleMP'>"
     with pytest.raises(NotImplementedError, match=does_not_support):
         dev.execute(circuit)
 
@@ -1491,14 +1491,13 @@ def test_unsupported_return_type():
     dev = _aws_device(wires=2, shots=4)
 
     mock_measurement = Mock()
-    mock_measurement.return_type = Enum("ObservableReturnTypes", {"Foo": "foo"}).Foo
     mock_measurement.obs = qml.PauliZ(0)
     mock_measurement.wires = qml.wires.Wires([0])
     mock_measurement.map_wires.return_value = mock_measurement
 
     tape = qml.tape.QuantumTape(measurements=[mock_measurement])
 
-    does_not_support = "Unsupported return type: ObservableReturnTypes.Foo"
+    does_not_support = "Unsupported return type: <class 'unittest.mock.Mock'>"
     with pytest.raises(NotImplementedError, match=does_not_support):
         dev.execute(tape)
 

--- a/test/unit_tests/test_translation.py
+++ b/test/unit_tests/test_translation.py
@@ -47,7 +47,6 @@ from device_property_jsons import (
 )
 from pennylane import measurements
 from pennylane import numpy as pnp
-from pennylane.measurements import ObservableReturnTypes
 from pennylane.pulse import ParametrizedEvolution, transmon_drive
 from pennylane.wires import Wires
 
@@ -366,11 +365,7 @@ _braket_to_pl = {
     for op in _BRAKET_TO_PENNYLANE_OPERATIONS
 }
 
-pl_return_types = [
-    ObservableReturnTypes.Expectation,
-    ObservableReturnTypes.Variance,
-    ObservableReturnTypes.Sample,
-]
+pl_return_types = [qml.expval, qml.var, qml.sample]
 
 braket_result_types = [
     Expectation(observables.H(), [0]),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`MeasurementProcess.return_type` and the associated `ObservableReturnType` enum was deprecated in pennylane v0.41 and has now been removed in latest PennyLane. This PR updates the plugin to use the recommended `isinstance` checks instead of checking the removed `return_type` property.

*Testing done:*

I ran all but the `test_ops.py` unit tests locally.  The required version of tensorflow was for `test_ops.py` was not available for my mac.

But other than that, the test seem fine with pennylane master installed.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.