### PR TITLE
infra: Use tf>=2.16.1 for tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,10 +19,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        exclude:
-          # tensorflow-macos doesn't support Python 3.13
-          - os: macos-latest
-            python-version: "3.13"
 
     steps:
     - uses: actions/checkout@v5

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Amazon Braket PennyLane Plugin
 .. image:: https://img.shields.io/pypi/pyversions/amazon-braket-pennylane-plugin.svg
     :alt: Supported Python Versions
     :target: https://pypi.python.org/pypi/amazon-braket-pennylane-plugin
-.. image:: https://img.shields.io/github/actions/workflow/status/amazon-braket/amazon-braket-strawberryfields-plugin-python/python-package.yml?branch=main&logo=github    
+.. image:: https://img.shields.io/github/actions/workflow/status/amazon-braket/amazon-braket-pennylane-plugin-python/python-package.yml?branch=main&logo=github
     :alt: Build Status
     :target: https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/actions?query=workflow%3A%22Python+package%22
 .. image:: https://codecov.io/gh/amazon-braket/amazon-braket-pennylane-plugin-python/branch/main/graph/badge.svg?token=VPPM8BJKW4

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import platform
-
 from setuptools import find_namespace_packages, setup
 
 with open("README.rst", "r") as fh:
@@ -20,11 +18,6 @@ with open("README.rst", "r") as fh:
 
 with open("src/braket/pennylane_plugin/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
-
-if platform.system() == "Darwin" and platform.machine() == "arm64":
-    TF_VERSION = "tensorflow-macos>=2.14.0"
-else:
-    TF_VERSION = "tensorflow>=2.14.0"
 
 setup(
     name="amazon-braket-pennylane-plugin",
@@ -71,7 +64,7 @@ setup(
             "sphinxcontrib-apidoc",
             "tox",
             "torch>2",
-            TF_VERSION,
+            "tensorflow>=2.16.1",
         ]
     },
     url="https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist = clean,linters,docs,unit-tests
 
-
 [testenv:clean]
 deps = coverage
 skip_install = true


### PR DESCRIPTION
With [TensorFlow 2.16.1](https://github.com/tensorflow/tensorflow/releases/tag/v2.16.1), `tensorflow-macos` has been retired in favor of a unified `tensorflow` package.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.