### PR TITLE
test: revert Temporarily xfail failing integ tests (#330)

### DIFF
--- a/test/integ_tests/test_counts.py
+++ b/test/integ_tests/test_counts.py
@@ -51,8 +51,6 @@ class TestCounts:
         the correct values when specifying a target
         """
         dev = device(2)
-        if "AwsDevice" in dev.name:
-            pytest.xfail()  # TODO: re-enable once this test case works on managed simulators
 
         @qml.qnode(dev)
         def circuit():
@@ -73,8 +71,6 @@ class TestCounts:
         the correct values when specifying an observable
         """
         dev = device(2)
-        if "AwsDevice" in dev.name:
-            pytest.xfail()  # TODO: re-enable once this test case works on managed simulators
 
         @qml.qnode(dev)
         def circuit():

--- a/test/integ_tests/test_var.py
+++ b/test/integ_tests/test_var.py
@@ -27,8 +27,6 @@ class TestVar:
     def test_var(self, device, shots, tol):
         """Tests for variance calculation"""
         dev = device(2)
-        if "AwsDevice" in dev.name:
-            pytest.xfail()  # TODO: re-enable once this test case works on managed simulators
 
         phi = 0.543
         theta = 0.6543
@@ -45,8 +43,6 @@ class TestVar:
     def test_var_hermitian(self, device, shots, tol):
         """Tests for variance calculation using an arbitrary Hermitian observable"""
         dev = device(2)
-        if "AwsDevice" in dev.name:
-            pytest.xfail()  # TODO: re-enable once this test case works on managed simulators
 
         phi = 0.543
         theta = 0.6543


### PR DESCRIPTION
This reverts commit 964a3ec975b3417e0367f70dd19e02c1127047c6.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.