### PR TITLE
fix: use correct wire order for program set expectation values

### DIFF
--- a/src/braket/pennylane_plugin/ahs_translation.py
+++ b/src/braket/pennylane_plugin/ahs_translation.py
@@ -173,7 +173,7 @@ def translate_ahs_shot_result(res: ShotResult):
         return np.array([np.nan for i in res.pre_sequence])
 
     # if a single atom failed to initialize, NaN for that individual measurement
-    pre_sequence = [i if i else np.nan for i in res.pre_sequence]
+    pre_sequence = [i or np.nan for i in res.pre_sequence]
 
     # set entry to 0 if ground state measured
     # 1 if excited state measured

--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -436,12 +436,17 @@ class BraketQubitDevice(QubitDevice):
         results = []
         for program_result, circuit in zip(program_set_result, circuits):
             # Only one executable per program
-            measurements = program_result[0].measurements
+            measured_entry = program_result[0]
+            measurements = measured_entry.measurements
+            # wire_order must span all measured qubits so each measurement selects its column
+            wire_order = measured_entry.measured_qubits
 
             # Program sets require shots > 0,
             # so the circuit's measurements are guaranteed to be SampleMeasurements
             executable_results = [
-                measurement.process_samples(measurements, wire_order=measurement.wires)
+                measurement.map_wires(self.wire_map).process_samples(
+                    measurements, wire_order=wire_order
+                )
                 for measurement in circuit.measurements
             ]
             results.append(

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -1123,6 +1123,90 @@ def test_batch_execute_program_set(mock_run):
     assert result[1] == 0.6
 
 
+def test_program_set_multiple_single_qubit_expvals_use_correct_wires():
+    """Regression test for pennylane-plugin issue #333 (and sdk issue #1316).
+
+    With multiple single-qubit expectations on distinct wires, each expval must reflect its
+    own qubit's measurements. Previously the program-set result handler passed
+    ``wire_order=measurement.wires`` (a single wire) while the sample array spans all measured
+    qubits, so every per-qubit expval collapsed to wire 0's value.
+    """
+    program_result = {
+        "braketSchemaHeader": {
+            "name": "braket.task_result.program_result",
+            "version": "1",
+        },
+        "executableResults": [
+            {
+                "braketSchemaHeader": {
+                    "name": "braket.task_result.program_set_executable_result",
+                    "version": "1",
+                },
+                # wire 0 always 0 (<Z> = +1); wire 1 always 1 (<Z> = -1)
+                "measurements": [[0, 1]] * 10,
+                "measuredQubits": [0, 1],
+                "inputsIndex": 0,
+            }
+        ],
+        "source": {
+            "braketSchemaHeader": {
+                "name": "braket.ir.openqasm.program",
+                "version": "1",
+            },
+            "source": "OPENQASM 3.0;",
+        },
+        "additionalMetadata": {
+            "simulatorMetadata": {
+                "braketSchemaHeader": {
+                    "name": "braket.task_result.simulator_metadata",
+                    "version": "1",
+                },
+                "executionDuration": 50,
+            }
+        },
+    }
+    ps_result = ProgramSetQuantumTaskResult.from_object(
+        ProgramSetTaskResult(
+            **{
+                "braketSchemaHeader": {
+                    "name": "braket.task_result.program_set_task_result",
+                    "version": "1",
+                },
+                "programResults": [program_result],
+                "taskMetadata": {
+                    "braketSchemaHeader": {
+                        "name": "braket.task_result.program_set_task_metadata",
+                        "version": "1",
+                    },
+                    "id": "arn:aws:braket:us-west-2:667256736152:quantum-task/abc",
+                    "deviceId": "arn:aws:braket:::device/quantum-simulator/amazon/sv1",
+                    "requestedShots": 10,
+                    "successfulShots": 10,
+                    "programMetadata": [{"executables": [{}]}],
+                    "createdAt": "2024-10-15T19:06:58.986Z",
+                    "endedAt": "2024-10-15T19:07:00.382Z",
+                    "status": "COMPLETED",
+                    "totalFailedExecutables": 0,
+                },
+            }
+        )
+    )
+
+    dev = _aws_device(wires=2, parallel=False, supports_program_sets=True)
+    with QuantumTape() as circuit:
+        qp.Hadamard(wires=0)
+        qp.CNOT(wires=[0, 1])
+        qp.expval(qp.PauliZ(0))
+        qp.expval(qp.PauliZ(1))
+
+    result = dev._braket_program_set_to_pl_result(ps_result, [circuit])
+
+    assert len(result) == 1
+    # wire 0 -> +1, wire 1 -> -1. The pre-fix bug returned (+1, +1).
+    assert result[0][0] == 1.0
+    assert result[0][1] == -1.0
+
+
 @patch.object(AwsDevice, "run")
 def test_batch_execute_program_set_parametrize_differentiable(mock_run):
     """Test batch_execute correctly runs program sets with trainable parameters"""

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -1124,13 +1124,8 @@ def test_batch_execute_program_set(mock_run):
 
 
 def test_program_set_multiple_single_qubit_expvals_use_correct_wires():
-    """Regression test for pennylane-plugin issue #333 (and sdk issue #1316).
-
-    With multiple single-qubit expectations on distinct wires, each expval must reflect its
-    own qubit's measurements. Previously the program-set result handler passed
-    ``wire_order=measurement.wires`` (a single wire) while the sample array spans all measured
-    qubits, so every per-qubit expval collapsed to wire 0's value.
-    """
+    """With multiple single-qubit expectations on distinct wires, each expval must reflect its
+    own qubit's measurements."""
     program_result = {
         "braketSchemaHeader": {
             "name": "braket.task_result.program_result",
@@ -1202,7 +1197,7 @@ def test_program_set_multiple_single_qubit_expvals_use_correct_wires():
     result = dev._braket_program_set_to_pl_result(ps_result, [circuit])
 
     assert len(result) == 1
-    # wire 0 -> +1, wire 1 -> -1. The pre-fix bug returned (+1, +1).
+    # wire 0 -> +1, wire 1 -> -1
     assert result[0][0] == 1.0
     assert result[0][1] == -1.0
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes #333.

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.